### PR TITLE
fix compiling on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,8 +18,8 @@ AC_SUBST([VERSION_COMMIT_SHA], ["m4_esyscmd([git rev-parse HEAD | tr -d '\n'])"]
 AC_PROG_CXX
 AC_PROG_CC
 
-CXXFLAGS+=" -std=c++11"
-CFLAGS+=" -std=c11"
+CXXFLAGS+=" -std=gnu++11"
+CFLAGS+=" -std=gnu11"
 
 AC_CONFIG_FILES([Makefile
                  include/Makefile

--- a/libgeneral/exception.cpp
+++ b/libgeneral/exception.cpp
@@ -6,6 +6,8 @@
 //  Copyright © 2018 tihmstar. All rights reserved.
 //
 
+#define _GNU_SOURCE
+
 #include "../include/libgeneral/macros.h"
 #include "../include/libgeneral/exception.hpp"
 #include <string.h>


### PR DESCRIPTION
switch language standard to gnu11/gnu++11 and also define _GNU_SOURCE in exception.cpp to enable compiling on windows.